### PR TITLE
Fixed issue where passwords containing @ would result in malformed URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-curl": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
If you attempt to use a password containing `@`, API requests silently fail.

This fix ensures that username/password credentials are properly encoded in API request URLs, and also handles any errors returned by libcurl.